### PR TITLE
seed the train/test split so scenarios are comparable

### DIFF
--- a/modules/assim.sequential/R/ensemble_downscale.R
+++ b/modules/assim.sequential/R/ensemble_downscale.R
@@ -229,6 +229,7 @@ ensemble_downscale <- function(ensemble_data, site_coords, covariates) {
     }
     if (n >= 10) {
       n_train <- max(1, floor(0.8 * n))
+      set.seed(42L + as.integer(ens_label))
       idx <- sample(seq_len(n), size = n_train)
       .train_data <- ens_data[idx, , drop = FALSE]
       .test_data <- ens_data[-idx, , drop = FALSE]

--- a/modules/assim.sequential/R/ensemble_downscale.R
+++ b/modules/assim.sequential/R/ensemble_downscale.R
@@ -381,13 +381,17 @@ downscale_metrics <- function(downscale_output) {
     mean <- mean(actual)
     RMSE <- sqrt(mean((actual - predicted)^2))
     MAE <- mean(abs(actual - predicted))
-    R2 <- 1 - sum((actual - predicted)^2) /
-      sum((actual - mean(actual))^2)
 
-    CV <- 100 * RMSE / mean
+    ss_res <- sum((actual - predicted)^2)
+    ss_tot <- sum((actual - mean(actual))^2)
+    R2 <- if (ss_tot == 0) NA_real_ else 1 - ss_res / ss_tot
 
-    if (CV > 500) {
-      PEcAn.logger::logger.error("Mean / RMSE > 500, indicating CV may not be an appropriate metric")
+    CV <- if (mean == 0) NA_real_ else 100 * RMSE / mean
+
+    if (!is.na(CV) && CV > 500) {
+      PEcAn.logger::logger.warn(
+        "CV > 500 (", round(CV, 1), "), indicating CV may not be an appropriate metric"
+      )
       CV <- NA
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
- ensemble_downscale function was doing an 80/20 train/test split inside random forest without controlling random seed. That function was originally written for single scenario use, so it didn't matter. But when we loop over multiple scenarios and compare them, each scenario was getting a different random split for the same ensemble member; RF approximation error from different splits was way bigger than the tillage signal, so it was just drowning it out. So setting a deterministic seed per
ensemble member so the split is identical across scenarios

- CH4 fluxes are tiny, so on some test partitions mean(actual) hit 0 and ss_tot hit 0, blowing up CV and R2; guard both with NA when the denominator is 0, and demote the CV > 500 message from error to warn

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] My name is in the list of CITATION.cff
- [ ] I agree that PEcAn Project may distribute my contribution under any or all of
	- the same license as the existing code,
	- and/or the BSD 3-clause license.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
